### PR TITLE
[codex] Add subscription OAuth model capture evidence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ DEEPSEEK_API_KEY=
 DASHSCOPE_API_KEY=
 ZHIPU_API_KEY=
 OPENROUTER_API_KEY=
+
+# Subscription OAuth (PRD-1.2) — use Claude Pro/Max or ChatGPT subscription
+# instead of API keys. Values: api_key (default) | oauth.
+# When set to "oauth" the matching *_API_KEY above may be left blank;
+# credentials are read from claude-cli / Codex CLI local storage.
+ANTHROPIC_AUTH_MODE=api_key
+OPENAI_AUTH_MODE=api_key

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,7 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Local OAuth diagnostics / smoke scripts
+_diag_*.py
+_smoke_*.py

--- a/README.md
+++ b/README.md
@@ -157,6 +157,64 @@ Alternatively, copy `.env.example` to `.env` and fill in your keys:
 cp .env.example .env
 ```
 
+### Subscription OAuth (Claude Pro/Max, ChatGPT)
+
+If you already have a Claude Pro/Max or ChatGPT subscription, you can run TradingAgents against your subscription quota instead of paying per-token API charges. Each analysis round makes 30–50 LLM calls (analyst team + bull/bear debate + risk debate), so this saves real money.
+
+OAuth mode is supported for **Anthropic and OpenAI only**. All other providers (Google, xAI, DeepSeek, Qwen, GLM, OpenRouter, Azure, Ollama) keep using their existing API key paths.
+
+**1. Log in with the official CLI** (one-time, on the host where TradingAgents will run):
+
+```bash
+# Anthropic — installs/uses claude-cli, opens a browser for Pro/Max OAuth
+claude   # then follow the login prompt; tokens land in ~/.claude/credentials.json
+
+# OpenAI — installs/uses Codex CLI, OAuth via ChatGPT account
+codex login   # tokens land in ~/.codex/auth.json (must be auth_mode="chatgpt", not "apikey")
+```
+
+**2. Enable OAuth in `.env`:**
+
+```bash
+ANTHROPIC_AUTH_MODE=oauth   # api_key (default) | oauth
+OPENAI_AUTH_MODE=oauth      # api_key (default) | oauth
+```
+
+When a provider is in `oauth` mode the matching `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` may be left blank — credentials are read from the local CLI storage above.
+
+**3. Override credential paths** (optional — useful for Docker, isolated test envs):
+
+```bash
+export CLAUDE_CREDENTIALS_FILE=/path/to/credentials.json
+export CODEX_AUTH_FILE=/path/to/auth.json
+```
+
+**Programmatic usage:**
+
+```python
+config = DEFAULT_CONFIG.copy()
+config["llm_provider"] = "anthropic"
+config["deep_think_llm"] = "claude-opus-4-7"
+config["quick_think_llm"] = "claude-sonnet-4-6"
+config["anthropic_auth_mode"] = "oauth"   # overrides ANTHROPIC_AUTH_MODE env
+# config["openai_auth_mode"] = "oauth"    # same idea for OpenAI
+```
+
+**Token expiry.** OAuth tokens are not auto-refreshed — if a token is expired the run fails fast with an actionable error (`run claude` / `run codex login`). Re-authenticate with the relevant CLI and retry. Background refresh is tracked in PRD-1.3.
+
+**Docker.** When running with `docker compose`, mount your credentials read-only so the container can see them:
+
+```yaml
+# docker-compose.override.yml
+services:
+  tradingagents:
+    volumes:
+      - ~/.claude:/root/.claude:ro      # Anthropic OAuth
+      - ~/.codex:/root/.codex:ro        # OpenAI OAuth
+```
+
+**Limitations.** Single-user / single-machine only. You are bound by your subscription's rate limits — for Claude Pro/Max this is a 5-hour rolling window, so a heavy run that exhausts the window will return `429 rate_limit_error` (not an auth failure) until it resets. Claude Code 2.1.126 model capture evidence is tracked in [docs/anthropic-oauth-model-capture-2026-05-02.md](docs/anthropic-oauth-model-capture-2026-05-02.md).
+
 ### CLI Usage
 
 Launch the interactive CLI:

--- a/docs/anthropic-oauth-model-capture-2026-05-02.md
+++ b/docs/anthropic-oauth-model-capture-2026-05-02.md
@@ -1,0 +1,47 @@
+# Anthropic OAuth model capture - 2026-05-02
+
+Context: GitHub issue #1 / PRD-1.2 section 8 item 5 asked whether Claude
+Code sends dated model IDs for Sonnet or Opus in OAuth mode.
+
+## Capture method
+
+- CLI: `claude --version` -> `2.1.126 (Claude Code)`.
+- Binary: `/home/kimsama/.local/share/claude/versions/2.1.126`.
+- Method: local HTTP capture server via `ANTHROPIC_BASE_URL` and
+  `CLAUDE_CODE_API_BASE_URL`.
+- The capture server parsed `/v1/messages` request bodies and printed only
+  `model`, `max_tokens`, and `stream`; headers and OAuth tokens were not logged.
+
+## Captured outbound model IDs
+
+| CLI model argument | Outbound `model` | Notes |
+| --- | --- | --- |
+| `sonnet` | `claude-sonnet-4-6` | Current Sonnet alias target. |
+| `opus` | `claude-opus-4-7` | Current Opus alias target. |
+| `claude-sonnet-4-5` | `claude-sonnet-4-5` | No dated remap observed. |
+| `claude-opus-4-5` | `claude-opus-4-5` | No dated remap observed. |
+
+The Claude Code binary does contain dated strings such as
+`claude-sonnet-4-5-20250929` and `claude-opus-4-5-20251101`, but they were not
+emitted by the tested Sonnet/Opus request paths.
+
+## Direct OAuth handshake result
+
+Using TradingAgents' Anthropic OAuth HTTP client and the captured current alias
+targets:
+
+| Model | Result |
+| --- | --- |
+| `claude-sonnet-4-6` | `429 rate_limit_error`, message `Error`, request `req_011CacuXVv6cHVEr1AGAz5S9`. |
+| `claude-opus-4-7` | `429 rate_limit_error`, message `Error`, request `req_011CacuXX7HJwkyZT2rV6ABn`. |
+
+No model-level `422` rejection was observed for these captured IDs. The current
+blocking condition is subscription/quota rate limiting, so a full success retry
+needs a fresh Claude limit window.
+
+## PRD-1.2 section 8 item 5 update
+
+The dated model ID hypothesis is not confirmed for Claude Code 2.1.126. Current
+Claude Code sends undated alias targets for the tested Sonnet and Opus paths.
+PRD-1.3 should seed model mapping from captured active aliases first, and only
+add dated forms after a live payload capture shows one being emitted.

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -23,6 +23,12 @@ class DummyLLMClient(BaseLLMClient):
 
 @pytest.mark.unit
 class ModelValidationTests(unittest.TestCase):
+    def test_anthropic_catalog_includes_captured_claude_cli_alias_targets(self):
+        models = set(get_known_models()["anthropic"])
+
+        self.assertIn("claude-sonnet-4-6", models)
+        self.assertIn("claude-opus-4-7", models)
+
     def test_cli_catalog_models_are_all_validator_approved(self):
         for provider, models in get_known_models().items():
             if provider in ("ollama", "openrouter"):

--- a/tests/test_oauth_clients.py
+++ b/tests/test_oauth_clients.py
@@ -1,0 +1,486 @@
+"""Unit tests for OAuth token managers (PRD-1.2 §6 step 1).
+
+Covers required scenarios:
+  - missing credentials file
+  - malformed credentials file
+  - expired token (load + http hook)
+  - happy path: required headers injected, x-api-key stripped
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import httpx
+import pytest
+
+from tradingagents.llm_clients.oauth import (
+    AnthropicOAuthCredentials,
+    AnthropicOAuthError,
+    OpenAIOAuthCredentials,
+    OpenAIOAuthError,
+    build_anthropic_http_client,
+    build_openai_http_client,
+    load_anthropic_credentials,
+    load_openai_credentials,
+)
+from tradingagents.llm_clients.oauth import anthropic_oauth, openai_oauth
+
+
+# --- helpers ----------------------------------------------------------------
+
+def _ms_from_now(seconds: int) -> int:
+    return int((time.time() + seconds) * 1000)
+
+
+def _make_jwt(exp_seconds_from_now: int) -> str:
+    """Minimal unsigned JWT with the requested `exp` claim."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": int(time.time()) + exp_seconds_from_now}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+def _write_claude_creds(tmp_path, *, expires_at_ms: int, access_token="sk-ant-oat-test", refresh_token="rt-test"):
+    creds_dir = tmp_path / ".claude"
+    creds_dir.mkdir(parents=True, exist_ok=True)
+    path = creds_dir / ".credentials.json"
+    path.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "expiresAt": expires_at_ms,
+        }
+    }))
+    return path
+
+
+def _write_codex_creds(tmp_path, *, jwt_exp_seconds=3600, access_token=None, account_id="acc-123"):
+    creds_dir = tmp_path / ".codex"
+    creds_dir.mkdir(parents=True, exist_ok=True)
+    path = creds_dir / "auth.json"
+    token = access_token if access_token is not None else _make_jwt(jwt_exp_seconds)
+    path.write_text(json.dumps({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "rt-codex",
+            "account_id": account_id,
+        },
+        "last_refresh": "2026-05-01T12:00:00Z",
+    }))
+    return path
+
+
+# --- Anthropic: missing / malformed -----------------------------------------
+
+@pytest.mark.unit
+def test_anthropic_missing_file_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    with pytest.raises(AnthropicOAuthError, match="not found"):
+        load_anthropic_credentials(home_dir=tmp_path)
+
+
+@pytest.mark.unit
+def test_anthropic_malformed_json_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    creds_dir = tmp_path / ".claude"
+    creds_dir.mkdir()
+    (creds_dir / ".credentials.json").write_text("{not json")
+    with pytest.raises(AnthropicOAuthError, match="invalid JSON"):
+        load_anthropic_credentials(home_dir=tmp_path)
+
+
+@pytest.mark.unit
+def test_anthropic_missing_oauth_block_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    creds_dir = tmp_path / ".claude"
+    creds_dir.mkdir()
+    (creds_dir / ".credentials.json").write_text(json.dumps({"some": "other"}))
+    with pytest.raises(AnthropicOAuthError, match="claudeAiOauth"):
+        load_anthropic_credentials(home_dir=tmp_path)
+
+
+@pytest.mark.unit
+def test_anthropic_env_override_used(tmp_path, monkeypatch):
+    custom = tmp_path / "elsewhere.json"
+    custom.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat-x",
+            "refreshToken": "r",
+            "expiresAt": _ms_from_now(3600),
+        }
+    }))
+    monkeypatch.setenv("CLAUDE_CREDENTIALS_FILE", str(custom))
+    creds = load_anthropic_credentials(home_dir=tmp_path)
+    assert creds.source_path == custom
+    assert creds.access_token == "sk-ant-oat-x"
+
+
+@pytest.mark.unit
+def test_anthropic_legacy_path_fallback(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    legacy_dir = tmp_path / ".claude"
+    legacy_dir.mkdir()
+    legacy = legacy_dir / "credentials.json"  # no leading dot
+    legacy.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat-legacy",
+            "refreshToken": "r",
+            "expiresAt": _ms_from_now(3600),
+        }
+    }))
+    creds = load_anthropic_credentials(home_dir=tmp_path)
+    assert creds.source_path == legacy
+
+
+# --- Anthropic: expired token -----------------------------------------------
+
+@pytest.mark.unit
+def test_anthropic_expired_credential_flag(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(-60))
+    creds = load_anthropic_credentials(home_dir=tmp_path)
+    assert creds.is_expired
+    assert creds.seconds_until_expiry == 0
+
+
+@pytest.mark.unit
+def test_anthropic_expired_token_blocks_request(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(-60))
+    client = build_anthropic_http_client(home_dir=tmp_path)
+    transport = httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True}))
+    client._transport = transport
+    with pytest.raises(AnthropicOAuthError, match="expired"):
+        client.get("/v1/messages")
+    client.close()
+
+
+# --- Anthropic: happy path / header verification ----------------------------
+
+@pytest.mark.unit
+def test_anthropic_required_headers_injected(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(3600))
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"ok": True})
+
+    client = build_anthropic_http_client(
+        home_dir=tmp_path,
+        extra_betas=["fine-grained-tool-streaming-2025-05-14"],
+        user_agent="claude-cli/9.9.9",
+    )
+    client._transport = httpx.MockTransport(handler)
+    # Prime an outgoing x-api-key to verify it gets stripped.
+    client.headers["x-api-key"] = "should-be-removed"
+    client.get("/v1/messages")
+    client.close()
+
+    h = captured["headers"]
+    assert h["authorization"] == "Bearer sk-ant-oat-test"
+    # Both required betas, in canonical order, plus the extra appended.
+    assert h["anthropic-beta"] == (
+        "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14"
+    )
+    assert h["user-agent"] == "claude-cli/9.9.9"
+    assert h["x-app"] == "cli"
+    assert h["anthropic-dangerous-direct-browser-access"] == "true"
+    assert "x-api-key" not in h
+
+
+@pytest.mark.unit
+def test_anthropic_dummy_key_is_obviously_fake():
+    assert "placeholder" in anthropic_oauth.get_dummy_key()
+
+
+# --- OpenAI / Codex: missing & malformed ------------------------------------
+
+@pytest.mark.unit
+def test_openai_missing_file_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex"))
+    with pytest.raises(OpenAIOAuthError, match="not found"):
+        load_openai_credentials()
+
+
+@pytest.mark.unit
+def test_openai_malformed_json_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("not json {")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    with pytest.raises(OpenAIOAuthError, match="invalid JSON"):
+        load_openai_credentials()
+
+
+@pytest.mark.unit
+def test_openai_missing_tokens_block_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(json.dumps({"unrelated": True}))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    with pytest.raises(OpenAIOAuthError, match="tokens"):
+        load_openai_credentials()
+
+
+# --- OpenAI / Codex: expiry handling ----------------------------------------
+
+@pytest.mark.unit
+def test_openai_jwt_expiry_decoded(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, jwt_exp_seconds=120)
+    creds = load_openai_credentials()
+    assert not creds.is_expired
+    assert 60 < creds.seconds_until_expiry <= 120
+
+
+@pytest.mark.unit
+def test_openai_non_jwt_falls_back_to_last_refresh(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, access_token="opaque-not-a-jwt")
+    creds = load_openai_credentials()
+    # last_refresh is 2026-05-01T12:00:00Z; +1h fallback. Expiry == frozen past.
+    assert creds.expires_at_ms > 0
+
+
+@pytest.mark.unit
+def test_openai_expired_token_blocks_request(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, jwt_exp_seconds=-60)
+    client = build_openai_http_client(home_dir=tmp_path)
+    client._transport = httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True}))
+    with pytest.raises(OpenAIOAuthError, match="expired"):
+        client.get("/responses")
+    client.close()
+
+
+@pytest.mark.unit
+def test_openai_env_override_used(tmp_path, monkeypatch):
+    custom = tmp_path / "elsewhere.json"
+    custom.write_text(json.dumps({
+        "tokens": {
+            "access_token": _make_jwt(3600),
+            "refresh_token": "r",
+            "account_id": "a",
+        }
+    }))
+    monkeypatch.setenv("CODEX_AUTH_FILE", str(custom))
+    creds = load_openai_credentials()
+    assert creds.source_path == custom
+    assert creds.account_id == "a"
+
+
+# --- OpenAI / Codex: happy path / headers -----------------------------------
+
+@pytest.mark.unit
+def test_openai_required_headers_injected(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, jwt_exp_seconds=3600)
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"ok": True})
+
+    client = build_openai_http_client(home_dir=tmp_path)
+    client._transport = httpx.MockTransport(handler)
+    client.get("/responses")
+    client.close()
+
+    h = captured["headers"]
+    assert h["authorization"].startswith("Bearer ")
+    assert h["chatgpt-account-id"] == "acc-123"
+
+
+@pytest.mark.unit
+def test_openai_dummy_key_is_obviously_fake():
+    assert "placeholder" in openai_oauth.get_dummy_key()
+
+
+# --- Factory wiring (PRD-1.2 §6 step 4) -------------------------------------
+#
+# Pin the contract between create_llm_client(...) and the per-provider
+# clients: auth_mode propagation through the factory, env-var fallback,
+# rejection for unsupported providers, and no regression for the default
+# api_key path.
+
+from tradingagents.llm_clients.factory import create_llm_client, _resolve_auth_mode
+from tradingagents.llm_clients.anthropic_client import AnthropicClient
+from tradingagents.llm_clients.openai_client import OpenAIClient
+
+
+@pytest.mark.unit
+def test_factory_default_auth_mode_is_api_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_AUTH_MODE", raising=False)
+    monkeypatch.delenv("OPENAI_AUTH_MODE", raising=False)
+    a = create_llm_client(provider="anthropic", model="claude-opus-4-7")
+    o = create_llm_client(provider="openai", model="gpt-5.4")
+    assert isinstance(a, AnthropicClient) and a.auth_mode == "api_key"
+    assert isinstance(o, OpenAIClient) and o.auth_mode == "api_key"
+
+
+@pytest.mark.unit
+def test_factory_explicit_oauth_propagates_to_anthropic_client():
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="oauth",
+    )
+    assert isinstance(client, AnthropicClient)
+    assert client.auth_mode == "oauth"
+
+
+@pytest.mark.unit
+def test_factory_explicit_oauth_propagates_to_openai_client():
+    client = create_llm_client(
+        provider="openai", model="gpt-5.4", auth_mode="oauth",
+    )
+    assert isinstance(client, OpenAIClient)
+    assert client.auth_mode == "oauth"
+    assert client.provider == "openai"
+
+
+@pytest.mark.unit
+def test_factory_env_var_fallback_anthropic(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_MODE", "oauth")
+    client = create_llm_client(provider="anthropic", model="claude-opus-4-7")
+    assert client.auth_mode == "oauth"
+
+
+@pytest.mark.unit
+def test_factory_env_var_fallback_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_AUTH_MODE", "oauth")
+    client = create_llm_client(provider="openai", model="gpt-5.4")
+    assert client.auth_mode == "oauth"
+
+
+@pytest.mark.unit
+def test_factory_explicit_arg_overrides_env_var(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_MODE", "oauth")
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="api_key",
+    )
+    assert client.auth_mode == "api_key"
+
+
+@pytest.mark.unit
+def test_factory_env_var_invalid_falls_back_to_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_MODE", "garbage")
+    assert _resolve_auth_mode("anthropic", None) == "api_key"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "provider", ["google", "azure", "xai", "deepseek", "qwen", "glm", "openrouter", "ollama"],
+)
+def test_factory_oauth_rejected_for_unsupported_provider(provider):
+    with pytest.raises(ValueError, match="oauth"):
+        create_llm_client(provider=provider, model="some-model", auth_mode="oauth")
+
+
+@pytest.mark.unit
+def test_openai_client_rejects_oauth_for_non_openai_provider():
+    """Belt-and-suspenders: even if factory bypassed, client guards itself."""
+    with pytest.raises(ValueError, match="provider='openai'"):
+        OpenAIClient(model="grok-4", provider="xai", auth_mode="oauth")
+
+
+# --- get_llm() injection through factory (PRD-1.2 §6 step 4) ----------------
+
+@pytest.mark.unit
+def test_factory_anthropic_oauth_get_llm_constructs(tmp_path, monkeypatch):
+    """Factory + oauth → get_llm() builds langchain wrapper without error.
+
+    No real HTTP call is made; we just verify the wrapper accepts the OAuth
+    http_client + dummy api_key kwargs the client injects.
+    """
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(3600))
+
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="oauth",
+    )
+    llm = client.get_llm()
+    assert llm.model == "claude-opus-4-7"
+
+
+@pytest.mark.unit
+def test_anthropic_oauth_http_client_reaches_sdk(tmp_path, monkeypatch):
+    """Regression: langchain_anthropic._client must use OUR http_client.
+
+    Without the NormalizedChatAnthropic._client override, langchain builds
+    its own httpx client and discards the OAuth one — silently breaking auth.
+    We assert the underlying anthropic.Client was constructed with our
+    OAuth httpx.Client instance, not a fresh one.
+    """
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(3600))
+
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="oauth",
+    )
+    llm = client.get_llm()
+    # Trigger _client cached_property build
+    sdk_client = llm._client
+    # The Anthropic SDK exposes the underlying httpx client as `_client`.
+    underlying_httpx = getattr(sdk_client, "_client", None)
+    assert underlying_httpx is llm._oauth_http_client, (
+        "OAuth httpx client was not propagated to the Anthropic SDK — "
+        "langchain wrapper is silently discarding it."
+    )
+
+
+@pytest.mark.unit
+def test_anthropic_api_key_mode_uses_default_sdk_client(monkeypatch):
+    """Regression: api_key mode must NOT trigger the OAuth http_client path."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="api_key",
+    )
+    llm = client.get_llm()
+    assert llm._oauth_http_client is None
+    # _client should construct via langchain's default helper, not crash.
+    assert llm._client is not None
+
+
+@pytest.mark.unit
+def test_factory_openai_oauth_disables_responses_api(tmp_path, monkeypatch):
+    """OAuth mode must NOT set use_responses_api=True (PRD §8 open question #2).
+
+    Codex subscription tokens are only confirmed to work on Chat Completions;
+    forcing /v1/responses risks breaking the round.
+    """
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, jwt_exp_seconds=3600)
+
+    client = create_llm_client(
+        provider="openai", model="gpt-5.4", auth_mode="oauth",
+    )
+    llm = client.get_llm()
+    assert getattr(llm, "use_responses_api", False) is not True
+
+
+@pytest.mark.unit
+def test_factory_openai_api_key_keeps_responses_api(monkeypatch):
+    """Regression guard: api_key path for native openai still uses Responses API."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-not-real")
+    client = create_llm_client(
+        provider="openai", model="gpt-5.4", auth_mode="api_key",
+    )
+    llm = client.get_llm()
+    assert getattr(llm, "use_responses_api", False) is True

--- a/tests/test_oauth_clients.py
+++ b/tests/test_oauth_clients.py
@@ -9,6 +9,7 @@ Covers required scenarios:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import time
@@ -22,7 +23,9 @@ from tradingagents.llm_clients.oauth import (
     OpenAIOAuthCredentials,
     OpenAIOAuthError,
     build_anthropic_http_client,
+    build_anthropic_http_client_async,
     build_openai_http_client,
+    build_openai_http_client_async,
     load_anthropic_credentials,
     load_openai_credentials,
 )
@@ -151,9 +154,8 @@ def test_anthropic_expired_credential_flag(tmp_path, monkeypatch):
 def test_anthropic_expired_token_blocks_request(tmp_path, monkeypatch):
     monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
     _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(-60))
-    client = build_anthropic_http_client(home_dir=tmp_path)
     transport = httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True}))
-    client._transport = transport
+    client = build_anthropic_http_client(home_dir=tmp_path, transport=transport)
     with pytest.raises(AnthropicOAuthError, match="expired"):
         client.get("/v1/messages")
     client.close()
@@ -176,8 +178,8 @@ def test_anthropic_required_headers_injected(tmp_path, monkeypatch):
         home_dir=tmp_path,
         extra_betas=["fine-grained-tool-streaming-2025-05-14"],
         user_agent="claude-cli/9.9.9",
+        transport=httpx.MockTransport(handler),
     )
-    client._transport = httpx.MockTransport(handler)
     # Prime an outgoing x-api-key to verify it gets stripped.
     client.headers["x-api-key"] = "should-be-removed"
     client.get("/v1/messages")
@@ -198,6 +200,51 @@ def test_anthropic_required_headers_injected(tmp_path, monkeypatch):
 @pytest.mark.unit
 def test_anthropic_dummy_key_is_obviously_fake():
     assert "placeholder" in anthropic_oauth.get_dummy_key()
+
+
+@pytest.mark.unit
+def test_anthropic_credentials_repr_redacts_tokens(tmp_path):
+    creds = AnthropicOAuthCredentials(
+        access_token="sk-ant-oat-secret",
+        refresh_token="rt-secret",
+        expires_at_ms=_ms_from_now(3600),
+        source_path=tmp_path / ".credentials.json",
+    )
+
+    text = repr(creds)
+
+    assert "sk-ant-oat-secret" not in text
+    assert "rt-secret" not in text
+    assert "access_token='<redacted>'" in text
+    assert "refresh_token='<redacted>'" in text
+
+
+@pytest.mark.unit
+def test_anthropic_async_required_headers_injected(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(3600))
+
+    captured = {}
+
+    async def run():
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"ok": True})
+
+        client = build_anthropic_http_client_async(
+            home_dir=tmp_path,
+            transport=httpx.MockTransport(handler),
+        )
+        client.headers["x-api-key"] = "should-be-removed"
+        await client.get("/v1/messages")
+        await client.aclose()
+
+    asyncio.run(run())
+
+    h = captured["headers"]
+    assert h["authorization"] == "Bearer sk-ant-oat-test"
+    assert h["anthropic-beta"] == "claude-code-20250219,oauth-2025-04-20"
+    assert "x-api-key" not in h
 
 
 # --- OpenAI / Codex: missing & malformed ------------------------------------
@@ -278,8 +325,10 @@ def test_openai_expired_token_blocks_request(tmp_path, monkeypatch):
     monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
     _write_codex_creds(tmp_path, jwt_exp_seconds=-60)
-    client = build_openai_http_client(home_dir=tmp_path)
-    client._transport = httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True}))
+    client = build_openai_http_client(
+        home_dir=tmp_path,
+        transport=httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+    )
     with pytest.raises(OpenAIOAuthError, match="expired"):
         client.get("/responses")
     client.close()
@@ -315,10 +364,36 @@ def test_openai_required_headers_injected(tmp_path, monkeypatch):
         captured["headers"] = dict(request.headers)
         return httpx.Response(200, json={"ok": True})
 
-    client = build_openai_http_client(home_dir=tmp_path)
-    client._transport = httpx.MockTransport(handler)
+    client = build_openai_http_client(home_dir=tmp_path, transport=httpx.MockTransport(handler))
     client.get("/responses")
     client.close()
+
+    h = captured["headers"]
+    assert h["authorization"].startswith("Bearer ")
+    assert h["chatgpt-account-id"] == "acc-123"
+
+
+@pytest.mark.unit
+def test_openai_async_required_headers_injected(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    _write_codex_creds(tmp_path, jwt_exp_seconds=3600)
+
+    captured = {}
+
+    async def run():
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"ok": True})
+
+        client = build_openai_http_client_async(
+            home_dir=tmp_path,
+            transport=httpx.MockTransport(handler),
+        )
+        await client.get("/responses")
+        await client.aclose()
+
+    asyncio.run(run())
 
     h = captured["headers"]
     assert h["authorization"].startswith("Bearer ")
@@ -464,6 +539,25 @@ def test_anthropic_oauth_http_client_reaches_sdk(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_anthropic_oauth_async_http_client_reaches_sdk(tmp_path, monkeypatch):
+    """Regression: async Anthropic SDK client must use OUR OAuth AsyncClient."""
+    monkeypatch.delenv("CLAUDE_CREDENTIALS_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_claude_creds(tmp_path, expires_at_ms=_ms_from_now(3600))
+
+    client = create_llm_client(
+        provider="anthropic", model="claude-opus-4-7", auth_mode="oauth",
+    )
+    llm = client.get_llm()
+    sdk_client = llm._async_client
+    underlying_httpx = getattr(sdk_client, "_client", None)
+    assert underlying_httpx is llm._oauth_http_async_client, (
+        "OAuth async httpx client was not propagated to the Anthropic SDK — "
+        "async langchain calls would silently use API-key auth."
+    )
+
+
+@pytest.mark.unit
 def test_anthropic_api_key_mode_uses_default_sdk_client(monkeypatch):
     """Regression: api_key mode must NOT trigger the OAuth http_client path."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
@@ -474,6 +568,29 @@ def test_anthropic_api_key_mode_uses_default_sdk_client(monkeypatch):
     assert llm._oauth_http_client is None
     # _client should construct via langchain's default helper, not crash.
     assert llm._client is not None
+
+
+@pytest.mark.unit
+def test_anthropic_api_key_mode_custom_http_clients_reach_sdk(monkeypatch):
+    """Explicit Anthropic http clients must not be silently discarded."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+    sync_client = httpx.Client()
+    async_client = httpx.AsyncClient()
+
+    try:
+        client = AnthropicClient(
+            model="claude-opus-4-7",
+            auth_mode="api_key",
+            http_client=sync_client,
+            http_async_client=async_client,
+        )
+        llm = client.get_llm()
+
+        assert getattr(llm._client, "_client", None) is sync_client
+        assert getattr(llm._async_client, "_client", None) is async_client
+    finally:
+        sync_client.close()
+        asyncio.run(async_client.aclose())
 
 
 @pytest.mark.unit
@@ -492,6 +609,7 @@ def test_factory_openai_oauth_disables_responses_api(tmp_path, monkeypatch):
     )
     llm = client.get_llm()
     assert getattr(llm, "use_responses_api", False) is not True
+    assert llm.http_async_client is not None
 
 
 @pytest.mark.unit

--- a/tests/test_oauth_clients.py
+++ b/tests/test_oauth_clients.py
@@ -405,6 +405,27 @@ def test_openai_dummy_key_is_obviously_fake():
     assert "placeholder" in openai_oauth.get_dummy_key()
 
 
+@pytest.mark.unit
+def test_openai_credentials_repr_redacts_tokens(tmp_path):
+    creds = OpenAIOAuthCredentials(
+        access_token="access-secret",
+        refresh_token="refresh-secret",
+        expires_at_ms=_ms_from_now(3600),
+        account_id="acc-123",
+        id_token="id-secret",
+        source_path=tmp_path / "auth.json",
+    )
+
+    text = repr(creds)
+
+    assert "access-secret" not in text
+    assert "refresh-secret" not in text
+    assert "id-secret" not in text
+    assert "access_token='<redacted>'" in text
+    assert "refresh_token='<redacted>'" in text
+    assert "id_token='<redacted>'" in text
+
+
 # --- Factory wiring (PRD-1.2 §6 step 4) -------------------------------------
 #
 # Pin the contract between create_llm_client(...) and the per-provider

--- a/tests/test_oauth_clients.py
+++ b/tests/test_oauth_clients.py
@@ -222,6 +222,25 @@ def test_openai_malformed_json_raises(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_openai_api_key_mode_auth_json_gives_actionable_error(tmp_path, monkeypatch):
+    """Codex CLI in api-key mode stores {auth_mode: apikey, OPENAI_API_KEY: ...}.
+
+    We must detect this and tell the user to run `codex login` rather than
+    emitting a confusing 'missing tokens object' message.
+    """
+    monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    creds_dir = tmp_path / ".codex"
+    creds_dir.mkdir(parents=True, exist_ok=True)
+    (creds_dir / "auth.json").write_text(json.dumps({
+        "auth_mode": "apikey",
+        "OPENAI_API_KEY": "sk-test-not-real",
+    }))
+    with pytest.raises(OpenAIOAuthError, match="codex login"):
+        load_openai_credentials(home_dir=tmp_path)
+
+
+@pytest.mark.unit
 def test_openai_missing_tokens_block_raises(tmp_path, monkeypatch):
     monkeypatch.delenv("CODEX_AUTH_FILE", raising=False)
     codex_home = tmp_path / ".codex"

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -15,6 +15,11 @@ DEFAULT_CONFIG = {
     "llm_provider": "openai",
     "deep_think_llm": "gpt-5.4",
     "quick_think_llm": "gpt-5.4-mini",
+    # Per-provider auth mode for subscription OAuth (PRD-1.2). Values:
+    # "api_key" (default), "oauth", or None to defer to <PROVIDER>_AUTH_MODE
+    # env var (then "api_key"). Only "anthropic" and "openai" support OAuth.
+    "anthropic_auth_mode": None,
+    "openai_auth_mode": None,
     # When None, each provider's client falls back to its own default endpoint
     # (api.openai.com for OpenAI, generativelanguage.googleapis.com for Gemini, ...).
     # The CLI overrides this per provider when the user picks one. Keeping a

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -82,16 +82,21 @@ class TradingAgentsGraph:
         if self.callbacks:
             llm_kwargs["callbacks"] = self.callbacks
 
+        provider = self.config["llm_provider"].lower()
+        auth_mode = self.config.get(f"{provider}_auth_mode")
+
         deep_client = create_llm_client(
             provider=self.config["llm_provider"],
             model=self.config["deep_think_llm"],
             base_url=self.config.get("backend_url"),
+            auth_mode=auth_mode,
             **llm_kwargs,
         )
         quick_client = create_llm_client(
             provider=self.config["llm_provider"],
             model=self.config["quick_think_llm"],
             base_url=self.config.get("backend_url"),
+            auth_mode=auth_mode,
             **llm_kwargs,
         )
 

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -15,17 +15,16 @@ _PASSTHROUGH_KWARGS = (
 
 
 class NormalizedChatAnthropic(ChatAnthropic):
-    """ChatAnthropic with normalized content + OAuth http_client injection.
+    """ChatAnthropic with normalized content + injected SDK http clients.
 
     Two reasons this subclass exists:
       1. Claude responses with extended thinking / tool use come back as a
          list of typed blocks; we flatten to a string for downstream agents.
-      2. OAuth mode requires a custom ``httpx.Client`` (bearer auth, beta
-         headers, x-api-key strip). ``langchain_anthropic.ChatAnthropic._client``
-         always builds its own httpx client and overrides anything we pass
-         via ``model_kwargs``, silently dropping our auth hook. We override
-         ``_client``/``_async_client`` to substitute the OAuth client when
-         ``_oauth_http_client`` is set.
+      2. OAuth mode and explicit ``http_client`` kwargs require custom httpx
+         clients. ``langchain_anthropic.ChatAnthropic._client`` always builds
+         its own httpx client and overrides anything we pass via
+         ``model_kwargs``, silently dropping our auth hook. We override
+         ``_client``/``_async_client`` to substitute injected clients.
     """
 
     # PrivateAttr keeps these off the request payload (Pydantic excludes them
@@ -36,18 +35,33 @@ class NormalizedChatAnthropic(ChatAnthropic):
     def invoke(self, input, config=None, **kwargs):
         return normalize_content(super().invoke(input, config, **kwargs))
 
+    def _get_client_params(self) -> dict[str, Any]:
+        client_params = getattr(self, "_client_params", None)
+        if client_params is None:
+            raise RuntimeError(
+                "langchain_anthropic.ChatAnthropic no longer exposes _client_params; "
+                "TradingAgents' injected http_client path needs updating."
+            )
+        return client_params
+
     @cached_property
     def _client(self) -> "anthropic.Client":  # type: ignore[override]
         if self._oauth_http_client is None:
             return super()._client  # default langchain behavior
-        client_params = self._client_params
+        client_params = self._get_client_params()
         return anthropic.Client(**{**client_params, "http_client": self._oauth_http_client})
 
     @cached_property
     def _async_client(self) -> "anthropic.AsyncClient":  # type: ignore[override]
         if self._oauth_http_async_client is None:
+            if self._oauth_http_client is not None:
+                from .oauth.anthropic_oauth import AnthropicOAuthError
+                raise AnthropicOAuthError(
+                    "Anthropic OAuth async http client was not configured; "
+                    "async OAuth calls are unavailable until this client is wired."
+                )
             return super()._async_client
-        client_params = self._client_params
+        client_params = self._get_client_params()
         return anthropic.AsyncClient(
             **{**client_params, "http_client": self._oauth_http_async_client}
         )
@@ -71,12 +85,14 @@ class AnthropicClient(BaseLLMClient):
         """Return configured ChatAnthropic instance."""
         self.warn_if_unknown_model()
         llm_kwargs = {"model": self.model}
-        oauth_http_client = None
+        injected_http_client = None
+        injected_http_async_client = None
 
         if self.auth_mode == "oauth":
-            from .oauth import build_anthropic_http_client
+            from .oauth import build_anthropic_http_client, build_anthropic_http_client_async
             from .oauth.anthropic_oauth import get_dummy_key
-            oauth_http_client = build_anthropic_http_client()
+            injected_http_client = build_anthropic_http_client()
+            injected_http_async_client = build_anthropic_http_client_async()
             # langchain_anthropic ignores a kwarg-supplied http_client; we
             # attach it as a PrivateAttr after construction (see
             # NormalizedChatAnthropic._client).
@@ -91,13 +107,21 @@ class AnthropicClient(BaseLLMClient):
                 if self.auth_mode == "oauth" and key == "api_key":
                     continue
                 # http_client(_async) flow through PrivateAttr, not kwargs.
-                if self.auth_mode == "oauth" and key in ("http_client", "http_async_client"):
+                if key == "http_client":
+                    if self.auth_mode != "oauth":
+                        injected_http_client = self.kwargs[key]
+                    continue
+                if key == "http_async_client":
+                    if self.auth_mode != "oauth":
+                        injected_http_async_client = self.kwargs[key]
                     continue
                 llm_kwargs[key] = self.kwargs[key]
 
         llm = NormalizedChatAnthropic(**llm_kwargs)
-        if oauth_http_client is not None:
-            llm._oauth_http_client = oauth_http_client
+        if injected_http_client is not None:
+            llm._oauth_http_client = injected_http_client
+        if injected_http_async_client is not None:
+            llm._oauth_http_async_client = injected_http_async_client
         return llm
 
     def validate_model(self) -> bool:

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -1,6 +1,9 @@
-from typing import Any, Optional
+from functools import cached_property
+from typing import Any, Literal, Optional
 
+import anthropic
 from langchain_anthropic import ChatAnthropic
+from pydantic import PrivateAttr
 
 from .base_client import BaseLLMClient, normalize_content
 from .validators import validate_model
@@ -12,36 +15,90 @@ _PASSTHROUGH_KWARGS = (
 
 
 class NormalizedChatAnthropic(ChatAnthropic):
-    """ChatAnthropic with normalized content output.
+    """ChatAnthropic with normalized content + OAuth http_client injection.
 
-    Claude models with extended thinking or tool use return content as a
-    list of typed blocks. This normalizes to string for consistent
-    downstream handling.
+    Two reasons this subclass exists:
+      1. Claude responses with extended thinking / tool use come back as a
+         list of typed blocks; we flatten to a string for downstream agents.
+      2. OAuth mode requires a custom ``httpx.Client`` (bearer auth, beta
+         headers, x-api-key strip). ``langchain_anthropic.ChatAnthropic._client``
+         always builds its own httpx client and overrides anything we pass
+         via ``model_kwargs``, silently dropping our auth hook. We override
+         ``_client``/``_async_client`` to substitute the OAuth client when
+         ``_oauth_http_client`` is set.
     """
+
+    # PrivateAttr keeps these off the request payload (Pydantic excludes them
+    # from model_dump). Public httpx clients are not JSON-serializable anyway.
+    _oauth_http_client: Optional[Any] = PrivateAttr(default=None)
+    _oauth_http_async_client: Optional[Any] = PrivateAttr(default=None)
 
     def invoke(self, input, config=None, **kwargs):
         return normalize_content(super().invoke(input, config, **kwargs))
+
+    @cached_property
+    def _client(self) -> "anthropic.Client":  # type: ignore[override]
+        if self._oauth_http_client is None:
+            return super()._client  # default langchain behavior
+        client_params = self._client_params
+        return anthropic.Client(**{**client_params, "http_client": self._oauth_http_client})
+
+    @cached_property
+    def _async_client(self) -> "anthropic.AsyncClient":  # type: ignore[override]
+        if self._oauth_http_async_client is None:
+            return super()._async_client
+        client_params = self._client_params
+        return anthropic.AsyncClient(
+            **{**client_params, "http_client": self._oauth_http_async_client}
+        )
 
 
 class AnthropicClient(BaseLLMClient):
     """Client for Anthropic Claude models."""
 
-    def __init__(self, model: str, base_url: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        *,
+        auth_mode: Literal["api_key", "oauth"] = "api_key",
+        **kwargs,
+    ):
         super().__init__(model, base_url, **kwargs)
+        self.auth_mode = auth_mode
 
     def get_llm(self) -> Any:
         """Return configured ChatAnthropic instance."""
         self.warn_if_unknown_model()
         llm_kwargs = {"model": self.model}
+        oauth_http_client = None
 
-        if self.base_url:
+        if self.auth_mode == "oauth":
+            from .oauth import build_anthropic_http_client
+            from .oauth.anthropic_oauth import get_dummy_key
+            oauth_http_client = build_anthropic_http_client()
+            # langchain_anthropic ignores a kwarg-supplied http_client; we
+            # attach it as a PrivateAttr after construction (see
+            # NormalizedChatAnthropic._client).
+            llm_kwargs.setdefault("api_key", get_dummy_key())
+        elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 
         for key in _PASSTHROUGH_KWARGS:
             if key in self.kwargs:
+                # In oauth mode, never let a stray API key from kwargs override
+                # the dummy placeholder — that would re-enable x-api-key auth.
+                if self.auth_mode == "oauth" and key == "api_key":
+                    continue
+                # http_client(_async) flow through PrivateAttr, not kwargs.
+                if self.auth_mode == "oauth" and key in ("http_client", "http_async_client"):
+                    continue
                 llm_kwargs[key] = self.kwargs[key]
 
-        return NormalizedChatAnthropic(**llm_kwargs)
+        llm = NormalizedChatAnthropic(**llm_kwargs)
+        if oauth_http_client is not None:
+            llm._oauth_http_client = oauth_http_client
+        return llm
 
     def validate_model(self) -> bool:
         """Validate model for Anthropic."""

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import os
+from typing import Literal, Optional
 
 from .base_client import BaseLLMClient
 
@@ -7,11 +8,35 @@ _OPENAI_COMPATIBLE = (
     "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
 )
 
+AuthMode = Literal["api_key", "oauth"]
+
+# Providers that support subscription-based OAuth (PRD-1.2). Other
+# providers raise if asked for OAuth — they only have API-key auth.
+_OAUTH_CAPABLE = ("anthropic", "openai")
+
+
+def _resolve_auth_mode(provider: str, explicit: Optional[AuthMode]) -> AuthMode:
+    """Resolve auth_mode from explicit arg or provider-specific env var.
+
+    Precedence: explicit arg > env var > "api_key" default. Env var name
+    mirrors the provider, e.g. ANTHROPIC_AUTH_MODE / OPENAI_AUTH_MODE.
+    """
+    if explicit is not None:
+        return explicit
+    env_value = os.environ.get(f"{provider.upper()}_AUTH_MODE")
+    if env_value:
+        normalized = env_value.strip().lower()
+        if normalized in ("api_key", "oauth"):
+            return normalized  # type: ignore[return-value]
+    return "api_key"
+
 
 def create_llm_client(
     provider: str,
     model: str,
     base_url: Optional[str] = None,
+    *,
+    auth_mode: Optional[AuthMode] = None,
     **kwargs,
 ) -> BaseLLMClient:
     """Create an LLM client for the specified provider.
@@ -24,23 +49,38 @@ def create_llm_client(
         provider: LLM provider name
         model: Model name/identifier
         base_url: Optional base URL for API endpoint
+        auth_mode: "api_key" (default) or "oauth". OAuth is supported for
+            "anthropic" (Claude Pro/Max) and "openai" (ChatGPT subscription)
+            only. If omitted, falls back to ``<PROVIDER>_AUTH_MODE`` env var
+            then to "api_key".
         **kwargs: Additional provider-specific arguments
 
     Returns:
         Configured BaseLLMClient instance
 
     Raises:
-        ValueError: If provider is not supported
+        ValueError: If provider is not supported, or if OAuth requested for
+            a provider that does not support it.
     """
     provider_lower = provider.lower()
+    resolved_auth = _resolve_auth_mode(provider_lower, auth_mode)
+
+    if resolved_auth == "oauth" and provider_lower not in _OAUTH_CAPABLE:
+        raise ValueError(
+            f"auth_mode='oauth' is not supported for provider '{provider}'. "
+            f"OAuth is only available for: {', '.join(_OAUTH_CAPABLE)}."
+        )
 
     if provider_lower in _OPENAI_COMPATIBLE:
         from .openai_client import OpenAIClient
-        return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)
+        return OpenAIClient(
+            model, base_url, provider=provider_lower,
+            auth_mode=resolved_auth, **kwargs,
+        )
 
     if provider_lower == "anthropic":
         from .anthropic_client import AnthropicClient
-        return AnthropicClient(model, base_url, **kwargs)
+        return AnthropicClient(model, base_url, auth_mode=resolved_auth, **kwargs)
 
     if provider_lower == "google":
         from .google_client import GoogleClient

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -30,6 +30,7 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Claude Sonnet 4.5 - Agents and coding", "claude-sonnet-4-5"),
         ],
         "deep": [
+            ("Claude Opus 4.7 - Most intelligent, agents and coding", "claude-opus-4-7"),
             ("Claude Opus 4.6 - Most intelligent, agents and coding", "claude-opus-4-6"),
             ("Claude Opus 4.5 - Premium, max intelligence", "claude-opus-4-5"),
             ("Claude Sonnet 4.6 - Best speed and intelligence balance", "claude-sonnet-4-6"),

--- a/tradingagents/llm_clients/oauth/__init__.py
+++ b/tradingagents/llm_clients/oauth/__init__.py
@@ -12,12 +12,14 @@ The token managers here only read.
 from .anthropic_oauth import (
     AnthropicOAuthError,
     AnthropicOAuthCredentials,
+    build_async_http_client as build_anthropic_http_client_async,
     build_http_client as build_anthropic_http_client,
     load_credentials as load_anthropic_credentials,
 )
 from .openai_oauth import (
     OpenAIOAuthError,
     OpenAIOAuthCredentials,
+    build_async_http_client as build_openai_http_client_async,
     build_http_client as build_openai_http_client,
     load_credentials as load_openai_credentials,
 )
@@ -26,9 +28,11 @@ __all__ = [
     "AnthropicOAuthError",
     "AnthropicOAuthCredentials",
     "build_anthropic_http_client",
+    "build_anthropic_http_client_async",
     "load_anthropic_credentials",
     "OpenAIOAuthError",
     "OpenAIOAuthCredentials",
     "build_openai_http_client",
+    "build_openai_http_client_async",
     "load_openai_credentials",
 ]

--- a/tradingagents/llm_clients/oauth/__init__.py
+++ b/tradingagents/llm_clients/oauth/__init__.py
@@ -1,0 +1,34 @@
+"""OAuth token managers for subscription-based LLM access.
+
+Reads credentials written by Claude Code (`~/.claude/.credentials.json`) and
+Codex CLI (`~/.codex/auth.json`) so TradingAgents can route requests through
+the user's Claude Pro/Max or ChatGPT subscription instead of API-key billing.
+
+Refresh is delegated to the source CLI (Claude Code / Codex) — running
+`claude` or `codex login` is the supported way to renew an expired token.
+The token managers here only read.
+"""
+
+from .anthropic_oauth import (
+    AnthropicOAuthError,
+    AnthropicOAuthCredentials,
+    build_http_client as build_anthropic_http_client,
+    load_credentials as load_anthropic_credentials,
+)
+from .openai_oauth import (
+    OpenAIOAuthError,
+    OpenAIOAuthCredentials,
+    build_http_client as build_openai_http_client,
+    load_credentials as load_openai_credentials,
+)
+
+__all__ = [
+    "AnthropicOAuthError",
+    "AnthropicOAuthCredentials",
+    "build_anthropic_http_client",
+    "load_anthropic_credentials",
+    "OpenAIOAuthError",
+    "OpenAIOAuthCredentials",
+    "build_openai_http_client",
+    "load_openai_credentials",
+]

--- a/tradingagents/llm_clients/oauth/anthropic_oauth.py
+++ b/tradingagents/llm_clients/oauth/anthropic_oauth.py
@@ -1,0 +1,222 @@
+"""Anthropic OAuth token manager (Claude Pro/Max subscription).
+
+Reads the credentials file written by Claude Code and exposes an
+`httpx.Client` preconfigured with the headers Anthropic requires for an
+OAuth bearer token. Refresh is intentionally NOT performed here — when the
+token has expired we raise so the user can run `claude` once and have the
+CLI rotate the file. This mirrors how Codex/Gemini adapters work today.
+
+Required headers (verified 2026-05-02 against OpenClaw v24.12.0 — same
+transport code path as claude-cli; see PRD-1.2 §5.5):
+
+    Authorization: Bearer <access_token>
+    anthropic-beta: claude-code-20250219,oauth-2025-04-20[,<extra-betas>]
+    user-agent: claude-cli/<version>
+    x-app: cli
+    anthropic-dangerous-direct-browser-access: true
+
+`x-api-key` must NOT be set — it conflicts with OAuth-mode auth on the
+Anthropic backend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import httpx
+
+
+_REQUIRED_BETAS = ("claude-code-20250219", "oauth-2025-04-20")
+_DEFAULT_USER_AGENT = "claude-cli/1.0.0"
+
+# Lookup order for the credentials file. Claude Code writes the leading-dot
+# variant; older docs / forks reference the no-dot variant. We accept both.
+_CREDENTIAL_PATH_ENV = "CLAUDE_CREDENTIALS_FILE"
+_CREDENTIAL_RELATIVE_PATHS = (
+    Path(".claude") / ".credentials.json",
+    Path(".claude") / "credentials.json",
+    Path(".config") / "claude" / "credentials.json",
+)
+
+
+class AnthropicOAuthError(RuntimeError):
+    """Raised when OAuth credentials are missing, malformed, or expired."""
+
+
+@dataclass(frozen=True)
+class AnthropicOAuthCredentials:
+    access_token: str
+    refresh_token: Optional[str]
+    expires_at_ms: int
+    source_path: Path
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at_ms <= _now_ms()
+
+    @property
+    def seconds_until_expiry(self) -> int:
+        return max(0, (self.expires_at_ms - _now_ms()) // 1000)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _candidate_paths(home_dir: Optional[Path] = None) -> Iterable[Path]:
+    override = os.environ.get(_CREDENTIAL_PATH_ENV)
+    if override:
+        yield Path(override).expanduser()
+    base = home_dir or Path.home()
+    for rel in _CREDENTIAL_RELATIVE_PATHS:
+        yield base / rel
+
+
+def _parse_credentials(raw: dict, source_path: Path) -> AnthropicOAuthCredentials:
+    block = raw.get("claudeAiOauth")
+    if not isinstance(block, dict):
+        raise AnthropicOAuthError(
+            f"{source_path}: missing 'claudeAiOauth' object — file does not look "
+            "like a Claude Code credentials.json"
+        )
+
+    access_token = block.get("accessToken")
+    expires_at = block.get("expiresAt")
+    refresh_token = block.get("refreshToken")
+
+    if not isinstance(access_token, str) or not access_token:
+        raise AnthropicOAuthError(f"{source_path}: claudeAiOauth.accessToken is missing or empty")
+    if not isinstance(expires_at, (int, float)) or expires_at <= 0:
+        raise AnthropicOAuthError(
+            f"{source_path}: claudeAiOauth.expiresAt is missing or not a positive number"
+        )
+
+    return AnthropicOAuthCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token if isinstance(refresh_token, str) and refresh_token else None,
+        expires_at_ms=int(expires_at),
+        source_path=source_path,
+    )
+
+
+def load_credentials(home_dir: Optional[Path] = None) -> AnthropicOAuthCredentials:
+    """Load Claude Code OAuth credentials from disk.
+
+    Search order:
+      1. `$CLAUDE_CREDENTIALS_FILE` (if set)
+      2. `~/.claude/.credentials.json` (current claude-cli default)
+      3. `~/.claude/credentials.json` (legacy / forks)
+      4. `~/.config/claude/credentials.json`
+
+    Raises:
+        AnthropicOAuthError: no candidate path exists, the file is malformed,
+            or required fields are missing.
+    """
+    tried: list[Path] = []
+    for path in _candidate_paths(home_dir):
+        tried.append(path)
+        if not path.exists():
+            continue
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise AnthropicOAuthError(f"{path}: invalid JSON ({exc})") from exc
+        if not isinstance(raw, dict):
+            raise AnthropicOAuthError(f"{path}: expected JSON object at top level")
+        return _parse_credentials(raw, path)
+
+    formatted = "\n  - ".join(str(p) for p in tried)
+    raise AnthropicOAuthError(
+        "Claude Code OAuth credentials not found. Looked at:\n  - "
+        + formatted
+        + "\nRun `claude` (Claude Code CLI) once to sign in, then retry."
+    )
+
+
+def get_dummy_key() -> str:
+    """Return a placeholder API key for langchain client init.
+
+    `langchain_anthropic.ChatAnthropic` requires `api_key` to pass startup
+    validation, but our custom `httpx.Client` injects the real bearer token
+    on every request and strips `x-api-key`. Returning a clearly-fake string
+    helps if it ever leaks into logs.
+    """
+    return "sk-ant-oauth-placeholder-not-a-real-key"
+
+
+def _build_headers(
+    credentials: AnthropicOAuthCredentials,
+    *,
+    extra_betas: Iterable[str] = (),
+    user_agent: Optional[str] = None,
+) -> dict[str, str]:
+    betas = list(_REQUIRED_BETAS)
+    for b in extra_betas:
+        if b and b not in betas:
+            betas.append(b)
+    return {
+        "authorization": f"Bearer {credentials.access_token}",
+        "anthropic-beta": ",".join(betas),
+        "user-agent": user_agent or _DEFAULT_USER_AGENT,
+        "x-app": "cli",
+        "anthropic-dangerous-direct-browser-access": "true",
+    }
+
+
+class _StripApiKeyAuth(httpx.Auth):
+    """httpx auth hook: enforce OAuth headers and remove conflicting x-api-key.
+
+    Re-reads credentials before each request would let us pick up
+    out-of-band rotations by claude-cli. For now we keep the snapshot taken
+    at client build time — Step 1 of the PRD doesn't include refresh — but
+    we still raise loudly if the snapshot is already past its expiry so the
+    failure mode is "401 with a confusing body" → "AnthropicOAuthError with
+    actionable message" instead.
+    """
+
+    requires_request_body = False
+    requires_response_body = False
+
+    def __init__(self, headers: dict[str, str], credentials: AnthropicOAuthCredentials):
+        self._headers = headers
+        self._credentials = credentials
+
+    def auth_flow(self, request):  # type: ignore[override]
+        if self._credentials.is_expired:
+            raise AnthropicOAuthError(
+                f"{self._credentials.source_path}: access token expired "
+                f"{(_now_ms() - self._credentials.expires_at_ms) // 1000}s ago. "
+                "Run `claude` to refresh, then retry."
+            )
+        request.headers.pop("x-api-key", None)
+        for k, v in self._headers.items():
+            request.headers[k] = v
+        yield request
+
+
+def build_http_client(
+    credentials: Optional[AnthropicOAuthCredentials] = None,
+    *,
+    base_url: str = "https://api.anthropic.com",
+    extra_betas: Iterable[str] = (),
+    user_agent: Optional[str] = None,
+    timeout: float = 600.0,
+    home_dir: Optional[Path] = None,
+) -> httpx.Client:
+    """Build an `httpx.Client` configured for Anthropic OAuth-mode requests.
+
+    The returned client is suitable for passing to `langchain_anthropic`
+    via `ChatAnthropic(http_client=...)`.
+    """
+    creds = credentials or load_credentials(home_dir=home_dir)
+    headers = _build_headers(creds, extra_betas=extra_betas, user_agent=user_agent)
+    return httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        auth=_StripApiKeyAuth(headers, creds),
+    )

--- a/tradingagents/llm_clients/oauth/anthropic_oauth.py
+++ b/tradingagents/llm_clients/oauth/anthropic_oauth.py
@@ -63,6 +63,16 @@ class AnthropicOAuthCredentials:
     def seconds_until_expiry(self) -> int:
         return max(0, (self.expires_at_ms - _now_ms()) // 1000)
 
+    def __repr__(self) -> str:
+        refresh_token = "'<redacted>'" if self.refresh_token else "None"
+        return (
+            f"{type(self).__name__}("
+            "access_token='<redacted>', "
+            f"refresh_token={refresh_token}, "
+            f"expires_at_ms={self.expires_at_ms!r}, "
+            f"source_path={self.source_path!r})"
+        )
+
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
@@ -207,6 +217,7 @@ def build_http_client(
     user_agent: Optional[str] = None,
     timeout: float = 600.0,
     home_dir: Optional[Path] = None,
+    transport: Optional[httpx.BaseTransport] = None,
 ) -> httpx.Client:
     """Build an `httpx.Client` configured for Anthropic OAuth-mode requests.
 
@@ -219,4 +230,26 @@ def build_http_client(
         base_url=base_url,
         timeout=timeout,
         auth=_StripApiKeyAuth(headers, creds),
+        transport=transport,
+    )
+
+
+def build_async_http_client(
+    credentials: Optional[AnthropicOAuthCredentials] = None,
+    *,
+    base_url: str = "https://api.anthropic.com",
+    extra_betas: Iterable[str] = (),
+    user_agent: Optional[str] = None,
+    timeout: float = 600.0,
+    home_dir: Optional[Path] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> httpx.AsyncClient:
+    """Build an async `httpx.AsyncClient` configured for Anthropic OAuth."""
+    creds = credentials or load_credentials(home_dir=home_dir)
+    headers = _build_headers(creds, extra_betas=extra_betas, user_agent=user_agent)
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        auth=_StripApiKeyAuth(headers, creds),
+        transport=transport,
     )

--- a/tradingagents/llm_clients/oauth/openai_oauth.py
+++ b/tradingagents/llm_clients/oauth/openai_oauth.py
@@ -112,6 +112,15 @@ def _parse_last_refresh_ms(value) -> Optional[int]:
 def _parse_credentials(raw: dict, source_path: Path) -> OpenAIOAuthCredentials:
     tokens = raw.get("tokens")
     if not isinstance(tokens, dict):
+        # Codex CLI stores api-key-mode auth in the same auth.json under
+        # {"auth_mode": "apikey", "OPENAI_API_KEY": "..."}. Detect that
+        # specifically so the user knows what to do.
+        if raw.get("auth_mode") == "apikey" or "OPENAI_API_KEY" in raw:
+            raise OpenAIOAuthError(
+                f"{source_path}: Codex CLI is in api-key mode (no subscription "
+                "OAuth tokens). Run `codex login` and choose the ChatGPT "
+                "subscription option to enable OAuth, then retry."
+            )
         raise OpenAIOAuthError(
             f"{source_path}: missing 'tokens' object — file does not look like a Codex auth.json"
         )

--- a/tradingagents/llm_clients/oauth/openai_oauth.py
+++ b/tradingagents/llm_clients/oauth/openai_oauth.py
@@ -87,6 +87,7 @@ def _decode_jwt_exp_ms(token: str) -> Optional[int]:
         payload_raw = parts[1]
         # urlsafe_b64decode requires correct padding
         padded = payload_raw + "=" * (-len(payload_raw) % 4)
+        # No signature verification: this is a UX fail-fast hint; the server is authoritative.
         payload = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
     except (ValueError, UnicodeDecodeError):
         return None
@@ -135,6 +136,7 @@ def _parse_credentials(raw: dict, source_path: Path) -> OpenAIOAuthCredentials:
     expires_at = _decode_jwt_exp_ms(access_token)
     if expires_at is None:
         last_refresh = _parse_last_refresh_ms(raw.get("last_refresh"))
+        # Heuristic: prefer attempting the call over blocking; the server will 401 if stale.
         base = last_refresh if last_refresh is not None else _now_ms()
         expires_at = base + _FALLBACK_TTL_S * 1000
 
@@ -204,6 +206,7 @@ class _BearerAuth(httpx.Auth):
                 f"{(_now_ms() - self._credentials.expires_at_ms) // 1000}s ago. "
                 "Run `codex login` to refresh, then retry."
             )
+        # Defensive: openai-python does not set api-key, but mirror Anthropic's strip pattern.
         request.headers.pop("api-key", None)
         for k, v in self._headers.items():
             request.headers[k] = v
@@ -216,6 +219,7 @@ def build_http_client(
     base_url: str = "https://api.openai.com/v1",
     timeout: float = 600.0,
     home_dir: Optional[Path] = None,
+    transport: Optional[httpx.BaseTransport] = None,
 ) -> httpx.Client:
     """Build an `httpx.Client` configured for OpenAI OAuth-mode requests."""
     creds = credentials or load_credentials(home_dir=home_dir)
@@ -224,4 +228,24 @@ def build_http_client(
         base_url=base_url,
         timeout=timeout,
         auth=_BearerAuth(headers, creds),
+        transport=transport,
+    )
+
+
+def build_async_http_client(
+    credentials: Optional[OpenAIOAuthCredentials] = None,
+    *,
+    base_url: str = "https://api.openai.com/v1",
+    timeout: float = 600.0,
+    home_dir: Optional[Path] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> httpx.AsyncClient:
+    """Build an async `httpx.AsyncClient` configured for OpenAI OAuth-mode requests."""
+    creds = credentials or load_credentials(home_dir=home_dir)
+    headers = _build_headers(creds)
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        auth=_BearerAuth(headers, creds),
+        transport=transport,
     )

--- a/tradingagents/llm_clients/oauth/openai_oauth.py
+++ b/tradingagents/llm_clients/oauth/openai_oauth.py
@@ -62,6 +62,18 @@ class OpenAIOAuthCredentials:
     def seconds_until_expiry(self) -> int:
         return max(0, (self.expires_at_ms - _now_ms()) // 1000)
 
+    def __repr__(self) -> str:
+        id_token = "'<redacted>'" if self.id_token else "None"
+        return (
+            f"{type(self).__name__}("
+            "access_token='<redacted>', "
+            "refresh_token='<redacted>', "
+            f"expires_at_ms={self.expires_at_ms!r}, "
+            f"account_id={self.account_id!r}, "
+            f"id_token={id_token}, "
+            f"source_path={self.source_path!r})"
+        )
+
 
 def _now_ms() -> int:
     return int(time.time() * 1000)

--- a/tradingagents/llm_clients/oauth/openai_oauth.py
+++ b/tradingagents/llm_clients/oauth/openai_oauth.py
@@ -1,0 +1,218 @@
+"""OpenAI (ChatGPT subscription) OAuth token manager via Codex CLI auth.json.
+
+Reads `~/.codex/auth.json` written by Codex CLI's `codex login` flow and
+exposes an `httpx.Client` that injects the bearer token on every request.
+
+File format (verified 2026-05-02 against OpenClaw v24.12.0
+`store-CcnCy00h.js:155`):
+
+    {
+      "tokens": {
+        "access_token": "...",        // JWT
+        "refresh_token": "...",
+        "account_id": "...",
+        "id_token": "..."             // optional
+      },
+      "last_refresh": "2026-05-01T12:34:56Z"
+    }
+
+Expiry is decoded from the access_token JWT's `exp` claim. If decoding
+fails, fall back to `last_refresh + 1 hour`. As with the Anthropic side we
+do not refresh — `codex login` is the supported renewal path.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+
+_AUTH_FILE_ENV = "CODEX_AUTH_FILE"
+_CODEX_HOME_ENV = "CODEX_HOME"
+_DEFAULT_CODEX_HOME = "~/.codex"
+_AUTH_FILENAME = "auth.json"
+_FALLBACK_TTL_S = 3600
+
+
+class OpenAIOAuthError(RuntimeError):
+    """Raised when Codex OAuth credentials are missing, malformed, or expired."""
+
+
+@dataclass(frozen=True)
+class OpenAIOAuthCredentials:
+    access_token: str
+    refresh_token: str
+    expires_at_ms: int
+    account_id: Optional[str]
+    id_token: Optional[str]
+    source_path: Path
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at_ms <= _now_ms()
+
+    @property
+    def seconds_until_expiry(self) -> int:
+        return max(0, (self.expires_at_ms - _now_ms()) // 1000)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _resolve_auth_path(home_dir: Optional[Path] = None) -> Path:
+    override = os.environ.get(_AUTH_FILE_ENV)
+    if override:
+        return Path(override).expanduser()
+    codex_home = os.environ.get(_CODEX_HOME_ENV) or _DEFAULT_CODEX_HOME
+    base = Path(codex_home).expanduser()
+    if home_dir is not None and not Path(codex_home).is_absolute() and codex_home == _DEFAULT_CODEX_HOME:
+        base = home_dir / ".codex"
+    return base / _AUTH_FILENAME
+
+
+def _decode_jwt_exp_ms(token: str) -> Optional[int]:
+    """Best-effort JWT `exp` extraction. Returns None if the token isn't a JWT."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        payload_raw = parts[1]
+        # urlsafe_b64decode requires correct padding
+        padded = payload_raw + "=" * (-len(payload_raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    exp = payload.get("exp")
+    if isinstance(exp, (int, float)) and exp > 0:
+        return int(exp * 1000)
+    return None
+
+
+def _parse_last_refresh_ms(value) -> Optional[int]:
+    if isinstance(value, (int, float)):
+        return int(value if value > 1e12 else value * 1000)
+    if isinstance(value, str):
+        from datetime import datetime
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return int(dt.timestamp() * 1000)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_credentials(raw: dict, source_path: Path) -> OpenAIOAuthCredentials:
+    tokens = raw.get("tokens")
+    if not isinstance(tokens, dict):
+        raise OpenAIOAuthError(
+            f"{source_path}: missing 'tokens' object — file does not look like a Codex auth.json"
+        )
+
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise OpenAIOAuthError(f"{source_path}: tokens.access_token is missing or empty")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise OpenAIOAuthError(f"{source_path}: tokens.refresh_token is missing or empty")
+
+    expires_at = _decode_jwt_exp_ms(access_token)
+    if expires_at is None:
+        last_refresh = _parse_last_refresh_ms(raw.get("last_refresh"))
+        base = last_refresh if last_refresh is not None else _now_ms()
+        expires_at = base + _FALLBACK_TTL_S * 1000
+
+    account_id = tokens.get("account_id") if isinstance(tokens.get("account_id"), str) else None
+    id_token = tokens.get("id_token") if isinstance(tokens.get("id_token"), str) else None
+
+    return OpenAIOAuthCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at_ms=expires_at,
+        account_id=account_id,
+        id_token=id_token,
+        source_path=source_path,
+    )
+
+
+def load_credentials(home_dir: Optional[Path] = None) -> OpenAIOAuthCredentials:
+    """Load Codex CLI OAuth credentials from disk.
+
+    Resolution:
+      1. `$CODEX_AUTH_FILE` (if set, used directly)
+      2. `$CODEX_HOME/auth.json`
+      3. `~/.codex/auth.json`
+    """
+    path = _resolve_auth_path(home_dir=home_dir)
+    if not path.exists():
+        raise OpenAIOAuthError(
+            f"Codex CLI auth file not found at {path}. "
+            "Run `codex login` once to sign in with your ChatGPT subscription, then retry."
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise OpenAIOAuthError(f"{path}: invalid JSON ({exc})") from exc
+    if not isinstance(raw, dict):
+        raise OpenAIOAuthError(f"{path}: expected JSON object at top level")
+    return _parse_credentials(raw, path)
+
+
+def get_dummy_key() -> str:
+    """Placeholder API key for langchain client init (real auth via http_client)."""
+    return "sk-codex-oauth-placeholder-not-a-real-key"
+
+
+def _build_headers(credentials: OpenAIOAuthCredentials) -> dict[str, str]:
+    headers = {
+        "authorization": f"Bearer {credentials.access_token}",
+    }
+    if credentials.account_id:
+        # Codex CLI sends this; some endpoints require it for subscription routing.
+        headers["chatgpt-account-id"] = credentials.account_id
+    return headers
+
+
+class _BearerAuth(httpx.Auth):
+    requires_request_body = False
+    requires_response_body = False
+
+    def __init__(self, headers: dict[str, str], credentials: OpenAIOAuthCredentials):
+        self._headers = headers
+        self._credentials = credentials
+
+    def auth_flow(self, request):  # type: ignore[override]
+        if self._credentials.is_expired:
+            raise OpenAIOAuthError(
+                f"{self._credentials.source_path}: access token expired "
+                f"{(_now_ms() - self._credentials.expires_at_ms) // 1000}s ago. "
+                "Run `codex login` to refresh, then retry."
+            )
+        request.headers.pop("api-key", None)
+        for k, v in self._headers.items():
+            request.headers[k] = v
+        yield request
+
+
+def build_http_client(
+    credentials: Optional[OpenAIOAuthCredentials] = None,
+    *,
+    base_url: str = "https://api.openai.com/v1",
+    timeout: float = 600.0,
+    home_dir: Optional[Path] = None,
+) -> httpx.Client:
+    """Build an `httpx.Client` configured for OpenAI OAuth-mode requests."""
+    creds = credentials or load_credentials(home_dir=home_dir)
+    headers = _build_headers(creds)
+    return httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        auth=_BearerAuth(headers, creds),
+    )

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from langchain_openai import ChatOpenAI
 
@@ -65,18 +65,33 @@ class OpenAIClient(BaseLLMClient):
         model: str,
         base_url: Optional[str] = None,
         provider: str = "openai",
+        *,
+        auth_mode: Literal["api_key", "oauth"] = "api_key",
         **kwargs,
     ):
         super().__init__(model, base_url, **kwargs)
         self.provider = provider.lower()
+        if auth_mode == "oauth" and self.provider != "openai":
+            raise ValueError(
+                f"auth_mode='oauth' is supported only for provider='openai', "
+                f"got provider='{self.provider}'."
+            )
+        self.auth_mode = auth_mode
 
     def get_llm(self) -> Any:
         """Return configured ChatOpenAI instance."""
         self.warn_if_unknown_model()
         llm_kwargs = {"model": self.model}
 
-        # Provider-specific base URL and auth
-        if self.provider in _PROVIDER_CONFIG:
+        if self.auth_mode == "oauth":
+            from .oauth import build_openai_http_client
+            from .oauth.openai_oauth import get_dummy_key
+            # Inject httpx.Client with ChatGPT-subscription bearer token.
+            # base_url is owned by the http_client; do not pass it through.
+            llm_kwargs["http_client"] = build_openai_http_client()
+            llm_kwargs.setdefault("api_key", get_dummy_key())
+        elif self.provider in _PROVIDER_CONFIG:
+            # Provider-specific base URL and auth
             base_url, api_key_env = _PROVIDER_CONFIG[self.provider]
             llm_kwargs["base_url"] = base_url
             if api_key_env:
@@ -91,11 +106,17 @@ class OpenAIClient(BaseLLMClient):
         # Forward user-provided kwargs
         for key in _PASSTHROUGH_KWARGS:
             if key in self.kwargs:
+                # In oauth mode, never let a stray API key from kwargs override
+                # the dummy placeholder — would re-enable api-key auth.
+                if self.auth_mode == "oauth" and key == "api_key":
+                    continue
                 llm_kwargs[key] = self.kwargs[key]
 
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.
-        if self.provider == "openai":
+        # OAuth mode falls back to Chat Completions (PRD-1.2 §8 open question
+        # #2: Codex tokens may not be accepted on /v1/responses).
+        if self.provider == "openai" and self.auth_mode != "oauth":
             llm_kwargs["use_responses_api"] = True
 
         return NormalizedChatOpenAI(**llm_kwargs)

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -84,11 +84,12 @@ class OpenAIClient(BaseLLMClient):
         llm_kwargs = {"model": self.model}
 
         if self.auth_mode == "oauth":
-            from .oauth import build_openai_http_client
+            from .oauth import build_openai_http_client, build_openai_http_client_async
             from .oauth.openai_oauth import get_dummy_key
-            # Inject httpx.Client with ChatGPT-subscription bearer token.
+            # Inject httpx clients with ChatGPT-subscription bearer token.
             # base_url is owned by the http_client; do not pass it through.
             llm_kwargs["http_client"] = build_openai_http_client()
+            llm_kwargs["http_async_client"] = build_openai_http_client_async()
             llm_kwargs.setdefault("api_key", get_dummy_key())
         elif self.provider in _PROVIDER_CONFIG:
             # Provider-specific base URL and auth
@@ -109,6 +110,8 @@ class OpenAIClient(BaseLLMClient):
                 # In oauth mode, never let a stray API key from kwargs override
                 # the dummy placeholder — would re-enable api-key auth.
                 if self.auth_mode == "oauth" and key == "api_key":
+                    continue
+                if self.auth_mode == "oauth" and key in ("http_client", "http_async_client"):
                     continue
                 llm_kwargs[key] = self.kwargs[key]
 


### PR DESCRIPTION
## Summary

- Adds Anthropic/OpenAI subscription OAuth documentation and links the Claude model-capture evidence.
- Records Claude Code 2.1.126 outbound model IDs for issue #1: `sonnet` -> `claude-sonnet-4-6`, `opus` -> `claude-opus-4-7`.
- Adds `claude-opus-4-7` to the Anthropic catalog and regression coverage for captured Claude CLI alias targets.
- Wires async OAuth HTTP clients for Anthropic and OpenAI so async SDK calls use subscription auth instead of silently falling back to API-key clients.
- Redacts both Anthropic and OpenAI OAuth credential reprs so access/refresh/ID tokens are not exposed in logs.

## Why

Issue #1 asked whether Claude Code sends dated Sonnet/Opus model IDs in OAuth mode. Local capture showed the current tested paths emit undated aliases, so PRD-1.3 model mapping should seed from captured active aliases first. Direct OAuth calls reached Anthropic and returned quota `429` responses rather than model-level `422` rejection.

The follow-up review identified async OAuth coverage as the approval blocker. This PR now builds and injects `httpx.AsyncClient` instances for both supported OAuth providers, adds regression tests for async header injection and Anthropic async SDK propagation, and keeps explicit Anthropic `http_client` passthrough from being silently discarded.

## Validation

- `uv run pytest tests/test_oauth_clients.py tests/test_model_validation.py` -> 50 passed.
- `uv run python _smoke_step5.py anthropic` -> failed during Phase A with `429 rate_limit_error`, request `req_011Cacx3Aim1x1PhCoeaptX9`. This is the known Claude subscription quota caveat, not a model rejection.

## Notes

- Closes #1.
- `uv.lock` remains a local uncommitted change and is not included in this PR.
- Local `_diag_*.py` / `_smoke_*.py` scripts are now ignored to avoid accidental commits.

